### PR TITLE
Space charts: add "use_last_value" field

### DIFF
--- a/librato/resource_librato_space_chart.go
+++ b/librato/resource_librato_space_chart.go
@@ -55,6 +55,11 @@ func resourceLibratoSpaceChart() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"use_last_value": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"stream": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -164,6 +169,9 @@ func resourceLibratoSpaceChartCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	if v, ok := d.GetOk("label"); ok {
 		spaceChart.Label = librato.String(v.(string))
+	}
+	if v, ok := d.GetOk("use_last_value"); ok {
+		spaceChart.UseLastValue = librato.Bool(v.(bool))
 	}
 	if v, ok := d.GetOk("related_space"); ok {
 		spaceChart.RelatedSpace = librato.Uint(uint(v.(int)))
@@ -280,6 +288,11 @@ func resourceLibratoSpaceChartReadResult(d *schema.ResourceData, chart *librato.
 			return err
 		}
 	}
+	if chart.UseLastValue != nil {
+		if err := d.Set("use_last_value", *chart.UseLastValue); err != nil {
+			return err
+		}
+	}
 	if chart.RelatedSpace != nil {
 		if err := d.Set("related_space", *chart.RelatedSpace); err != nil {
 			return err
@@ -370,6 +383,10 @@ func resourceLibratoSpaceChartUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("label") {
 		spaceChart.Label = librato.String(d.Get("label").(string))
 		fullChart.Label = spaceChart.Label
+	}
+	if d.HasChange("use_last_value") {
+		spaceChart.UseLastValue = librato.Bool(d.Get("use_last_value").(bool))
+		fullChart.UseLastValue = spaceChart.UseLastValue
 	}
 	if d.HasChange("related_space") {
 		spaceChart.RelatedSpace = librato.Uint(d.Get("related_space").(uint))

--- a/librato/resource_librato_space_chart_test.go
+++ b/librato/resource_librato_space_chart_test.go
@@ -199,6 +199,7 @@ resource "librato_space_chart" "foobar" {
     min = 0
     max = 100
     label = "Percent"
+		use_last_value = false
     related_space = "${librato_space.barbaz.id}"
 
     # Minimal metric stream

--- a/vendor/github.com/henrikhodne/go-librato/librato/spaces_charts.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/spaces_charts.go
@@ -13,6 +13,7 @@ type SpaceChart struct {
 	Min          *float64           `json:"min,omitempty"`
 	Max          *float64           `json:"max,omitempty"`
 	Label        *string            `json:"label,omitempty"`
+	UseLastValue *bool              `json:"use_last_value,omitempty"`
 	RelatedSpace *uint              `json:"related_space,omitempty"`
 	Streams      []SpaceChartStream `json:"streams,omitempty"`
 }

--- a/website/docs/r/space_chart.html.markdown
+++ b/website/docs/r/space_chart.html.markdown
@@ -50,11 +50,12 @@ The following arguments are supported:
 
 * `space_id` - (Required) The ID of the space this chart should be in.
 * `name` - (Required) The title of the chart when it is displayed.
-* `type` - (Optional) Indicates the type of chart. Must be one of line or
-  stacked (default to line).
+* `type` - (Optional) Indicates the type of chart. Must be one of line,
+  stacked, or bignumber (default to line).
 * `min` - (Optional) The minimum display value of the chart's Y-axis.
 * `max` - (Optional) The maximum display value of the chart's Y-axis.
 * `label` - (Optional) The Y-axis label.
+* `use_last_value` - (Optional) Use the most recent value (default) or summarize the chart.
 * `related_space` - (Optional) The ID of another space to which this chart is
   related.
 * `stream` - (Optional) Nested block describing a metric to use for data in the


### PR DESCRIPTION
(I am not an experienced golang developer, so any tips or corrections are welcome)

This addition allows configuring if the last value is used, or if the summary function is applied. 

Please note, this changeset includes a [cherry-picked commit](https://github.com/mikedougherty/terraform-provider-librato/commit/ca03281d4b8f6eea8df6bc8f65c1426cd6d0b16b) for a vendored library (`go-librato`). This change has been submitted upstream here: https://github.com/henrikhodne/go-librato/pull/14. If it isn't appropriate to directly change files in `vendor/`, I can remove this change. Of course, this PR will then be blocked on updating this vendored library if/when my other PR is merged.

My organization is very interested in porting all of our Librato dashboards to terraform and this change will help us get there.