### PR TITLE
update the vendored go-librato library

### DIFF
--- a/vendor/github.com/henrikhodne/go-librato/librato/annotation.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/annotation.go
@@ -1,0 +1,49 @@
+package librato
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// AnnotationsService handles communication with the Librato API methods related to
+// Annotations.
+type AnnotationsService struct {
+	client *Client
+}
+
+// Annotation represents a Librato Annotation.
+type Annotation struct {
+	Name        *string          `json:"name"`
+	Title       *string          `json:"title"`
+	Source      *string          `json:"source,omitempty"`
+	Description *string          `json:"description,omitempty"`
+	Links       []AnnotationLink `json:"links,omitempty"`
+	StartTime   *uint            `json:"start_time,omitempty"`
+	EndTime     *uint            `json:"end_time,omitempty"`
+}
+
+// AnnotationLink represents a Librato Annotation Link.
+type AnnotationLink struct {
+	Label *string `json:"label,omitempty"`
+	Rel   *string `json:"rel"`
+	Href  *string `json:"href,omitempty"`
+}
+
+// Create an Annotation
+//
+// Librato API docs: https://www.librato.com/docs/api/?shell#create-an-Annotation
+func (a *AnnotationsService) Create(annotation *Annotation) (*Annotation, *http.Response, error) {
+	u := fmt.Sprintf("annotations/%s", *annotation.Name)
+	req, err := a.client.NewRequest("POST", u, annotation)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	an := new(Annotation)
+	resp, err := a.client.Do(req, an)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return an, resp, err
+}

--- a/vendor/github.com/henrikhodne/go-librato/librato/client.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/client.go
@@ -44,10 +44,11 @@ type Client struct {
 	UserAgent string
 
 	// Services used to manipulate API entities.
-	Spaces   *SpacesService
-	Metrics  *MetricsService
-	Alerts   *AlertsService
-	Services *ServicesService
+	Spaces      *SpacesService
+	Metrics     *MetricsService
+	Alerts      *AlertsService
+	Services    *ServicesService
+	Annotations *AnnotationsService
 }
 
 // NewClient returns a new Librato API client bound to the public Librato API.
@@ -80,6 +81,7 @@ func NewClientWithBaseURL(baseURL *url.URL, email, token string) *Client {
 	c.Metrics = &MetricsService{client: c}
 	c.Alerts = &AlertsService{client: c}
 	c.Services = &ServicesService{client: c}
+	c.Annotations = &AnnotationsService{client: c}
 
 	return c
 }
@@ -140,7 +142,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 		return resp, err
 	}
 
-	if v != nil {
+	if v != nil && resp.ContentLength != 0 {
 		if w, ok := v.(io.Writer); ok {
 			_, err = io.Copy(w, resp.Body)
 		} else {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -521,10 +521,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "o9U0fbkAJEUAszp4RHNjrCZaaX0=",
+			"checksumSHA1": "Byj4rRoQ8/KfGkNSE2SCMityh0w=",
 			"path": "github.com/henrikhodne/go-librato/librato",
-			"revision": "92cd9647dc6914b228205c03def7f57f7248fbe8",
-			"revisionTime": "2017-06-25T18:27:10Z"
+			"revision": "cd4baae4da94deaa0cfcf819c048a0e6a041c37a",
+			"revisionTime": "2017-10-24T21:52:50Z"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",


### PR DESCRIPTION
This brings in https://github.com/henrikhodne/go-librato/pull/13 , when
creating/updating composite metrics the response can be empty which
will result in an error even though librato successfully created the
metric.